### PR TITLE
Major (2x) code speedup with minimal changes to the code

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(name = "triceratops",
         'Topic :: Scientific/Engineering :: Astronomy'
         ],
       install_requires=['numpy>=1.18.1','pandas>=0.23.4', 'scipy>=1.1.0', 'matplotlib>=3.0.3',
-                        'astropy>=3.1.2', 'astroquery>=0.4', 'batman-package>=2.4.6',
+                        'astropy>=3.1.2', 'astroquery>=0.4', 'pytransit>=2.2',
                         'mechanicalsoup>=0.12.0'],
       zip_safe=False
 )


### PR DESCRIPTION
Hi Steven,

Great work with the package :)

Here is a simple change that leads to a major (2x) speedup. I changed the code to use PyTransit instead of Batman to calculate the light curves. This leads to 2 times faster evaluation speed of the example notebook cases without changing the results (because the generated light curves are identical).

If you're happy with the change, I can probably accelerate the code significantly more (5-20 times faster) by switching it to use PyTransit's parallelised LC evaluation methods.

Cheers,
Hannu