### PR TITLE
Fix add_star() regression

### DIFF
--- a/triceratops/triceratops.py
+++ b/triceratops/triceratops.py
@@ -273,7 +273,7 @@ class target:
                 self.pix_coords[i],
                 self.pix_coords[i][0]
                 ).reshape(
-                self.pix_coords[i]+1, 2
+                len(self.pix_coords[i])+1, 2
                 )
         return
 

--- a/triceratops/triceratops.py
+++ b/triceratops/triceratops.py
@@ -8,6 +8,7 @@ import astropy.units as u
 import numpy as np
 from astroquery.vizier import Vizier
 from scipy.integrate import dblquad
+import pandas as pd
 from pandas import DataFrame, read_csv
 from math import floor, ceil
 import matplotlib.pyplot as plt
@@ -264,7 +265,12 @@ class target:
             new_star = DataFrame(
                 [[str(ID), Tmag]], columns=["ID", "Tmag"]
                 )
-        self.stars = self.stars.append(new_star)
+        # MUST reset_index of the concatenated data frame
+        # to ensure the indices of each row is unique.
+        # Otherwise update_star() might produce incorrect result
+        # (updating multiple rows with the same index)
+        self.stars = pd.concat([self.stars, new_star]).reset_index(drop=True)
+
         # for each set of pixel coordinates (corresponding to
         # each sector), append a row for the new star with the same
         # coordinates as the target star


### PR DESCRIPTION
1. Fixed a regression in `target.add_star()` 
2. Also tweaked pandas call to avoid Deprecation Warning by replacing `df.append()` with `pd.cocnat()` . `pd.cocnat()` has been available since pandas v1.0 so the change should be safe.

It might be wise to bump minimum version of pandas to 1.0 as well:

https://github.com/stevengiacalone/triceratops/blob/7d6d2baf0b39f0f7439d52fefdc99652f2040c00/setup.py#L24