### PR TITLE
Fixed `remove_star()`, so it'd correctly operate on int IDs

### DIFF
--- a/triceratops/triceratops.py
+++ b/triceratops/triceratops.py
@@ -293,6 +293,10 @@ class target:
             drop_stars (numpy array): Array of (int) TIC IDs
                 for stars to drop.
         """
+        # convert drop_stars to an array of str for actual matching
+        if np.isscalar(drop_stars):
+            drop_stars = [drop_stars]
+        drop_stars = [str(s) for s in drop_stars]
         self.stars = self.stars[~self.stars["ID"].isin(drop_stars)]
         return
 


### PR DESCRIPTION
1. Fixed the bug in `remove_star()` has a bug such that it is a no-op if the IDs supplied at ints.
2. Make remove_star() supports a single int, in addition to an array of ints, for convenience.


