### PR TITLE
Expose TIC table columns that indicate a TIC is possibly problematic  (spurious objects, etc.)

### DIFF
--- a/triceratops/triceratops.py
+++ b/triceratops/triceratops.py
@@ -111,7 +111,10 @@ class target:
             )
         new_df = df[
             "ID", "Tmag", "Jmag", "Hmag", "Kmag",
-            "ra", "dec", "mass", "rad", "Teff", "plx"
+            "ra", "dec", "mass", "rad", "Teff", "plx",
+            # for spurious objects, etc.
+            # see https://arxiv.org/abs/2108.04778 Section 3.1 for details
+            "disposition", "duplicate_id"
             ]
         stars = new_df.to_pandas()
 


### PR DESCRIPTION
The scenario I ran into that led to using `remove_star()` (and thus the PR #33 fix) is that a nearby star is a 2MASS artifact, indicated in TIC table's disposition column [*].

It'd be helpful to expose columns `"disposition"` and `"duplicate_id"` in `target.stars`, giving users a chance to easily review and make decisions.

A more aggressive alternative is to automatically remove problematic entries, e.g., removing those with disposition of `"ARTIFACT"` or `"DUPLICATE"` (unless it is the target itself).

--

[*] See https://outerspace.stsci.edu/display/TESS/TIC+v8.2+and+CTL+v8.xx+Data+Release+Notes#TICv8.2andCTLv8.xxDataReleaseNotes-UpdatestoTIC8(v8.1andv8.2) for the specifics.
