### PR TITLE
fix: Python 3.12 / NumPy 2.x / setuptools 82+ compatibility

### DIFF
--- a/triceratops/funcs.py
+++ b/triceratops/funcs.py
@@ -188,10 +188,16 @@ def Gauss2D(x, y, mu_x, mu_y, sigma, A):
         A (float): Area under Gaussian.
     Returns:
     """
+    # dblquad passes scalar x/y; np.meshgrid on scalars returns 0-d arrays
+    # on NumPy 2.x, which scipy cannot convert internally. Fast-path for
+    # the scalar case (the only case dblquad uses).
+    if np.ndim(x) == 0 and np.ndim(y) == 0:
+        x0, y0 = float(x), float(y)
+        exponent = ((x0 - mu_x)**2 + (y0 - mu_y)**2) / (2*sigma**2)
+        return float(A / (2*np.pi*sigma**2) * np.exp(-exponent))
     xgrid, ygrid = np.meshgrid(x, y)
     exponent = ((xgrid-mu_x)**2 + (ygrid-mu_y)**2)/(2*sigma**2)
-    GaussExp = np.exp(-exponent)
-    return A/(2*np.pi*sigma**2)*GaussExp
+    return A/(2*np.pi*sigma**2)*np.exp(-exponent)
 
 
 def file_to_contrast_curve(contrast_curve_file: str):

--- a/triceratops/likelihoods.py
+++ b/triceratops/likelihoods.py
@@ -1,5 +1,12 @@
 import numpy as np
 from astropy import constants
+
+# NumPy 2.0 removed np.trapz (renamed to np.trapezoid). Inject the alias
+# before pytransit's module-level import runs so older pytransit releases
+# load cleanly. No-op on NumPy < 2.0.
+if not hasattr(np, "trapz"):
+    np.trapz = np.trapezoid  # type: ignore[attr-defined]
+
 from pytransit import QuadraticModel
 
 Msun = constants.M_sun.cgs.value

--- a/triceratops/likelihoods.py
+++ b/triceratops/likelihoods.py
@@ -1,9 +1,14 @@
 import numpy as np
 from astropy import constants
 
-# NumPy 2.0 removed np.trapz (renamed to np.trapezoid). Inject the alias
-# before pytransit's module-level import runs so older pytransit releases
-# load cleanly. No-op on NumPy < 2.0.
+# Older pytransit releases use NumPy aliases removed in modern NumPy.
+# Inject shims before the pytransit import runs; both guards are no-ops
+# on NumPy versions where the names still exist.
+#
+# np.int (Python builtin alias): removed in NumPy 1.24.
+# np.trapz (renamed to np.trapezoid): removed in NumPy 2.0.
+if not hasattr(np, "int"):
+    np.int = int  # type: ignore[attr-defined]
 if not hasattr(np, "trapz"):
     np.trapz = np.trapezoid  # type: ignore[attr-defined]
 

--- a/triceratops/marginal_likelihoods.py
+++ b/triceratops/marginal_likelihoods.py
@@ -1,7 +1,7 @@
 import numpy as np
 from pandas import read_csv
 from astropy import constants
-from pkg_resources import resource_filename
+from pathlib import Path
 
 from .likelihoods import *
 from .priors import *
@@ -17,9 +17,10 @@ au = constants.au.cgs.value
 pi = np.pi
 ln2pi = np.log(2*pi)
 
+_DATA_DIR = Path(__file__).parent / "data"
+
 # load TESS limb darkening coefficients
-LDC_FILE = resource_filename('triceratops', 'data/ldc_tess.csv')
-ldc_T = read_csv(LDC_FILE)
+ldc_T = read_csv(_DATA_DIR / "ldc_tess.csv")
 ldc_T_Zs = np.array(ldc_T.Z, dtype=float)
 ldc_T_Teffs = np.array(ldc_T.Teff, dtype=int)
 ldc_T_loggs = np.array(ldc_T.logg, dtype=float)
@@ -27,8 +28,7 @@ ldc_T_u1s = np.array(ldc_T.aLSM, dtype=float)
 ldc_T_u2s = np.array(ldc_T.bLSM, dtype=float)
 
 # load Kepler limb darkening coefficients
-LDC_FILE = resource_filename('triceratops', 'data/ldc_kepler.csv')
-ldc_K = read_csv(LDC_FILE)
+ldc_K = read_csv(_DATA_DIR / "ldc_kepler.csv")
 ldc_K_Zs = np.array(ldc_K.Z, dtype=float)
 ldc_K_Teffs = np.array(ldc_K.Teff, dtype=int)
 ldc_K_loggs = np.array(ldc_K.logg, dtype=float)
@@ -94,7 +94,7 @@ def lnZ_TTP(time: np.ndarray, flux: np.ndarray, sigma: float,
         & (ldc_Teffs == this_Teff)
         & (ldc_loggs == this_logg)
         )
-    u1, u2 = ldc_u1s[mask], ldc_u2s[mask]
+    u1, u2 = ldc_u1s[mask].item(), ldc_u2s[mask].item()
 
     # sample from prior distributions
     rps = sample_rp(np.random.rand(N), np.full(N, M_s), flatpriors)
@@ -233,7 +233,7 @@ def lnZ_TEB(time: np.ndarray, flux: np.ndarray, sigma: float,
         & (ldc_Teffs == this_Teff)
         & (ldc_loggs == this_logg)
         )
-    u1, u2 = ldc_u1s[mask], ldc_u2s[mask]
+    u1, u2 = ldc_u1s[mask].item(), ldc_u2s[mask].item()
 
     # sample from prior distributions
     incs = sample_inc(np.random.rand(N))
@@ -457,7 +457,7 @@ def lnZ_PTP(time: np.ndarray, flux: np.ndarray, sigma: float,
         & (ldc_Teffs == this_Teff)
         & (ldc_loggs == this_logg)
         )
-    u1, u2 = ldc_u1s[mask], ldc_u2s[mask]
+    u1, u2 = ldc_u1s[mask].item(), ldc_u2s[mask].item()
 
     # sample from q prior distributions
     if molusc_file is None:
@@ -665,7 +665,7 @@ def lnZ_PEB(time: np.ndarray, flux: np.ndarray, sigma: float,
         & (ldc_Teffs == this_Teff)
         & (ldc_loggs == this_logg)
         )
-    u1, u2 = ldc_u1s[mask], ldc_u2s[mask]
+    u1, u2 = ldc_u1s[mask].item(), ldc_u2s[mask].item()
 
     # sample from prior distributions
     incs = sample_inc(np.random.rand(N))
@@ -1484,7 +1484,7 @@ def lnZ_DTP(time: np.ndarray, flux: np.ndarray, sigma: float,
         & (ldc_Teffs == this_Teff)
         & (ldc_loggs == this_logg)
         )
-    u1, u2 = ldc_u1s[mask], ldc_u2s[mask]
+    u1, u2 = ldc_u1s[mask].item(), ldc_u2s[mask].item()
 
     # determine background star population properties
     (Tmags_comp, masses_comp, loggs_comp, Teffs_comp, Zs_comp,
@@ -1681,7 +1681,7 @@ def lnZ_DEB(time: np.ndarray, flux: np.ndarray, sigma: float,
         & (ldc_Teffs == this_Teff)
         & (ldc_loggs == this_logg)
         )
-    u1, u2 = ldc_u1s[mask], ldc_u2s[mask]
+    u1, u2 = ldc_u1s[mask].item(), ldc_u2s[mask].item()
 
     # sample from inc and q prior distributions
     incs = sample_inc(np.random.rand(N))
@@ -2965,7 +2965,7 @@ def lnZ_NTP_evolved(time: np.ndarray, flux: np.ndarray, sigma: float,
         & (ldc_Teffs == this_Teff)
         & (ldc_loggs == this_logg)
         )
-    u1, u2 = ldc_u1s[mask], ldc_u2s[mask]
+    u1, u2 = ldc_u1s[mask].item(), ldc_u2s[mask].item()
 
     # sample from inc and R_p prior distributions
     rps = sample_rp(np.random.rand(N), np.full(N, M_s), flatpriors)
@@ -3106,7 +3106,7 @@ def lnZ_NEB_evolved(time: np.ndarray, flux: np.ndarray, sigma: float,
         & (ldc_Teffs == this_Teff)
         & (ldc_loggs == this_logg)
         )
-    u1, u2 = ldc_u1s[mask], ldc_u2s[mask]
+    u1, u2 = ldc_u1s[mask].item(), ldc_u2s[mask].item()
 
     # sample from inc and q prior distributions
     incs = sample_inc(np.random.rand(N))

--- a/triceratops/marginal_likelihoods.py
+++ b/triceratops/marginal_likelihoods.py
@@ -992,7 +992,7 @@ def lnZ_STP(time: np.ndarray, flux: np.ndarray, sigma: float,
             zip(rounded_Teffs_comp, rounded_loggs_comp)
             ):
         mask = (Teffs_at_Z == comp_Teff) & (loggs_at_Z == comp_logg)
-        u1s_comp[i], u2s_comp[i] = u1s_at_Z[mask], u2s_at_Z[mask]
+        u1s_comp[i], u2s_comp[i] = u1s_at_Z[mask].item(), u2s_at_Z[mask].item()
 
     # calculate priors for companions
     if molusc_file is None:
@@ -1212,7 +1212,7 @@ def lnZ_SEB(time: np.ndarray, flux: np.ndarray, sigma: float,
             zip(rounded_Teffs_comp, rounded_loggs_comp)
             ):
         mask = (Teffs_at_Z == comp_Teff) & (loggs_at_Z == comp_logg)
-        u1s_comp[i], u2s_comp[i] = u1s_at_Z[mask], u2s_at_Z[mask]
+        u1s_comp[i], u2s_comp[i] = u1s_at_Z[mask].item(), u2s_at_Z[mask].item()
 
     # calculate properties of the drawn EBs
     masses = qs*masses_comp
@@ -1974,7 +1974,7 @@ def lnZ_BTP(time: np.ndarray, flux: np.ndarray, sigma: float,
             & (ldc_Teffs == this_Teff)
             & (ldc_loggs == this_logg)
             )
-        u1s_comp[i], u2s_comp[i] = ldc_u1s[mask], ldc_u2s[mask]
+        u1s_comp[i], u2s_comp[i] = ldc_u1s[mask].item(), ldc_u2s[mask].item()
     # draw random sample of background stars
     idxs = np.random.randint(0, N_comp, N)
 
@@ -2192,7 +2192,7 @@ def lnZ_BEB(time: np.ndarray, flux: np.ndarray, sigma: float,
             & (ldc_Teffs == this_Teff)
             & (ldc_loggs == this_logg)
             )
-        u1s_comp[i], u2s_comp[i] = ldc_u1s[mask], ldc_u2s[mask]
+        u1s_comp[i], u2s_comp[i] = ldc_u1s[mask].item(), ldc_u2s[mask].item()
     # draw random sample of background stars
     idxs = np.random.randint(0, N_comp, N)
 
@@ -2511,7 +2511,7 @@ def lnZ_NTP_unknown(time: np.ndarray, flux: np.ndarray, sigma: float,
             & (ldc_Teffs == this_Teff)
             & (ldc_loggs == this_logg)
             )
-        u1s_possible[i], u2s_possible[i] = ldc_u1s[mask], ldc_u2s[mask]
+        u1s_possible[i], u2s_possible[i] = ldc_u1s[mask].item(), ldc_u2s[mask].item()
     # draw random sample of background stars
     if N_possible > 0:
         idxs = np.random.randint(0, N_possible, N)
@@ -2710,7 +2710,7 @@ def lnZ_NEB_unknown(time: np.ndarray, flux: np.ndarray, sigma: float,
             & (ldc_Teffs == this_Teff)
             & (ldc_loggs == this_logg)
             )
-        u1s_possible[i], u2s_possible[i] = ldc_u1s[mask], ldc_u2s[mask]
+        u1s_possible[i], u2s_possible[i] = ldc_u1s[mask].item(), ldc_u2s[mask].item()
     # draw random sample of background stars
     if N_possible > 0:
         idxs = np.random.randint(0, N_possible, N)

--- a/triceratops/triceratops.py
+++ b/triceratops/triceratops.py
@@ -609,13 +609,13 @@ class target:
                 this_flux = 0
                 for j in range(len(all_ap_pixels[k])):
                     this_pixel = all_ap_pixels[k][j]
-                    this_flux += dblquad(
+                    this_flux += float(dblquad(
                         Gauss2D,
                         this_pixel[1]-0.5,
                         this_pixel[1]+0.5,
                         this_pixel[0]-0.5,
                         this_pixel[0]+0.5,
-                        args=(mu_x, mu_y, 0.75, A))[0]
+                        args=(mu_x, mu_y, 0.75, A))[0])
                 rel_flux_per_aperture[k, i] = this_flux
             # calculate flux ratios for this aperture
             flux_ratio_per_aperture[k, :] = (


### PR DESCRIPTION
# fix: Python 3.12 / NumPy 2.x / setuptools 82+ compatibility

## Summary

Six mechanical fixes restoring compatibility with modern Python environments.
No logic changes, no new dependencies, ~30 lines total.

## Problem

The package fails to import and run on Python 3.12 with NumPy >= 2.0 and
setuptools >= 82. These are pre-existing issues in `master`.

## Fixes

### 1. `likelihoods.py`: `np.int` removed in NumPy 1.24

Older `pytransit` releases use `from numpy import ... int` at module level.
NumPy 1.24 removed `numpy.int` (a redundant alias for Python's built-in
`int`), causing the package to fail to import:

```
ImportError: cannot import name 'int' from 'numpy'
```

Fix: inject a shim before the `pytransit` import:

```python
if not hasattr(np, "int"):
    np.int = int  # type: ignore[attr-defined]
```

---

### 2. `likelihoods.py`: `np.trapz` removed in NumPy 2.0

Older `pytransit` releases also use `numpy.trapz` at module level. NumPy 2.0
removed it (renamed to `numpy.trapezoid`):

```
ImportError: cannot import name 'trapz' from 'numpy'
```

Fix: inject a second shim alongside Fix 1:

```python
if not hasattr(np, "trapz"):
    np.trapz = np.trapezoid  # type: ignore[attr-defined]
```

Both shims are no-ops on NumPy versions where the names still exist.

---

### 3. `marginal_likelihoods.py`: `pkg_resources` removed in setuptools 82

`setuptools` 82+ removed the `pkg_resources` top-level module.
`marginal_likelihoods.py` used `resource_filename` to locate the two
limb-darkening CSV data files at import time:

```
ModuleNotFoundError: No module named 'pkg_resources'
```

Fix: replace with `pathlib.Path` (stdlib since Python 3.4):

```python
# Before
from pkg_resources import resource_filename
ldc_T = read_csv(resource_filename('triceratops', 'data/ldc_tess.csv'))
ldc_K = read_csv(resource_filename('triceratops', 'data/ldc_kepler.csv'))

# After
from pathlib import Path
_DATA_DIR = Path(__file__).parent / "data"
ldc_T = read_csv(_DATA_DIR / "ldc_tess.csv")
ldc_K = read_csv(_DATA_DIR / "ldc_kepler.csv")
```

`Path(__file__).parent / "data"` resolves correctly in both installed and
editable (`pip install -e`) modes.

---

### 4. `marginal_likelihoods.py`: boolean mask indexing returns array, not scalar (NumPy 2.x, 14 sites)

Each `lnZ_*` function extracts limb-darkening coefficients using a boolean
mask lookup. On NumPy 2.x, boolean-mask indexing always returns a 1-D array,
even when exactly one row matches. This breaks in two distinct ways depending
on the assignment target:

**Pattern A -- direct variable assignment (8 sites):** downstream `float()`
conversion raises:
```
TypeError: only 0-dimensional arrays can be converted to Python scalars
```

**Pattern B -- pre-allocated array element assignment (6 sites):** NumPy
rejects storing a 1-element array into a scalar slot:
```
ValueError: setting an array element with a sequence
```

All three assignment forms appear in the file:

```python
# Pattern A (8 sites) -- direct variable
u1, u2 = ldc_u1s[mask], ldc_u2s[mask]

# Pattern B1 (4 sites) -- companion star array
u1s_comp[i], u2s_comp[i] = u1s_at_Z[mask], u2s_at_Z[mask]
u1s_comp[i], u2s_comp[i] = ldc_u1s[mask], ldc_u2s[mask]

# Pattern B2 (2 sites) -- possible star array
u1s_possible[i], u2s_possible[i] = ldc_u1s[mask], ldc_u2s[mask]
```

Fix: use `.item()` at all 14 sites:

```python
u1, u2 = ldc_u1s[mask].item(), ldc_u2s[mask].item()
u1s_comp[i], u2s_comp[i] = ldc_u1s[mask].item(), ldc_u2s[mask].item()
u1s_possible[i], u2s_possible[i] = ldc_u1s[mask].item(), ldc_u2s[mask].item()
```

`.item()` extracts the Python scalar and raises `ValueError` if the mask
ever matches more than one row, which enforces the single-match invariant
that the lookup logic already guarantees.

---

### 5. `triceratops.py`: `dblquad` returns 0-d array, not `float` (newer scipy)

In `calc_depths`, the `dblquad` result is accumulated into `this_flux`:

```python
this_flux += dblquad(...)[0]   # 0-d ndarray on newer scipy
```

Newer scipy returns a 0-d `ndarray` rather than a Python `float`. Accumulating
it converts `this_flux` to a 0-d array, which then fails as a bound argument
in a subsequent `scipy.integrate` call.

Fix: explicit `float()` cast:

```python
this_flux += float(dblquad(...)[0])
```

---

### 6. `funcs.py`: `Gauss2D` scalar fast-path for NumPy 2.x

`dblquad` calls its integrand (`Gauss2D`) with scalar `x`, `y` values.
`np.meshgrid` on scalar inputs returns 0-d arrays on NumPy 2.x, which
scipy's internal integration routine cannot convert to a Python scalar.
This causes `calc_depths` to fail even after Fix 5.

Fix: add a scalar fast-path that bypasses `meshgrid` when both inputs are 0-d:

```python
if np.ndim(x) == 0 and np.ndim(y) == 0:
    x0, y0 = float(x), float(y)
    exponent = ((x0 - mu_x)**2 + (y0 - mu_y)**2) / (2*sigma**2)
    return float(A / (2*np.pi*sigma**2) * np.exp(-exponent))
```

The existing `meshgrid` path is preserved for the array use-case documented
in the function's docstring.

---

## Testing

The existing test suite passes. End-to-end verification against real TESS
data (including the `calc_depths` -> `calc_probs` path) should be performed
locally before merge.

## Relationship to other branches

This branch contains only compatibility fixes and is intended to merge first.
The numerical stability fix (`fix/logsumexp-marginal-likelihood`) is rebased
on top of this commit.